### PR TITLE
fix: bound mcp below 2.x — the published wheel could not be imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cameras could not be deleted** — the sensor wrapper re-created the prim a tick later.
 - **Commands sent during startup failed with a raw `AttributeError`** — the socket opens seconds before Kit has a stage.
 - **`apply_material` leaked a raw USD C++ error** naming NVIDIA's build tree.
+- **`pip install isaacsim-mcp-server` produced a package that could not start** — the `mcp` dependency was unbounded, so a fresh install resolved mcp 2.x, where `FastMCP` was renamed and `mcp.server.fastmcp` no longer exists. This affects 0.5.2 on PyPI today, not only this release.
 - **`create_object(color=...)` was accepted and discarded** — the parameter was documented and sent, no prim was ever coloured, and the call reported success.
 - **`search_usd` dropped `position` and `scale`** — the asset landed at the origin at native scale, reported as success.
 - **`set_joint_positions` reported the same success whether or not the robot took the command** — when the articulation refuses it, the values are written to USD drive targets, which move nothing until physics initialises again. The response now carries `command_source` and warns on the fallback.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,16 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
+    # Both bounds are load-bearing, and they fail in opposite directions.
+    #   >= 2     renamed FastMCP to MCPServer, so an unbounded spec made every
+    #            `pip install` of this package fail at import. Loud.
+    #   < 1.3.0  FastMCP.__init__(self, name=None, **settings) swallows
+    #            `instructions=`, so the server starts, serves all 42 tools and
+    #            silently loses the whole agent contract. Measured against the
+    #            built wheel: 1.2.0 drops it, 1.3.0 keeps it (3546 chars).
+    # 1.9.0 sits deliberately above the 1.3.0 floor: it is the oldest version
+    # exercised end to end here, and for a published package being stricter
+    # than necessary is the safe direction.
     "mcp[cli]>=1.9.0,<2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "mcp[cli]",
+    "mcp[cli]>=1.9.0,<2",
 ]
 
 [dependency-groups]

--- a/tests/test_packaging_constraints.py
+++ b/tests/test_packaging_constraints.py
@@ -1,0 +1,78 @@
+# MIT License
+#
+# Copyright (c) 2023-2025 omni-mcp
+# Copyright (c) 2026 whats2000
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The published wheel must constrain its one runtime dependency.
+
+`mcp[cli]` was unbounded, so `pip install isaacsim-mcp-server` resolved mcp 2.x,
+where FastMCP was renamed to MCPServer. Every fresh install died on import:
+
+    ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x,
+    where FastMCP was renamed to MCPServer ... or pin 'mcp<2'
+
+Nothing in the repo could see it: uv.lock pins 1.28.1 so `uv run` works, and CI
+installs only ruff and pytest by pip, never the package itself. It is only
+visible by installing the built wheel into a clean environment.
+
+The bounds are measured, not guessed: 1.9.0, 1.15.0 and 1.28.1 each serve all
+42 tools through the installed console script; 2.1.1 cannot be imported.
+"""
+
+import os
+import re
+
+PYPROJECT = os.path.join(os.path.dirname(__file__), "..", "pyproject.toml")
+
+
+def _dependency(name):
+    """The dependency entry for `name`.
+
+    Collect lines until the array's closing bracket on its own line -- splitting
+    on the first "]" truncates inside "mcp[cli]" and silently returns a partial
+    entry, which is a test that passes for the wrong reason.
+    """
+    with open(PYPROJECT) as f:
+        lines = f.read().splitlines()
+    inside = False
+    for line in lines:
+        if line.startswith("dependencies = ["):
+            inside = True
+            continue
+        if inside:
+            if line.strip() == "]":
+                break
+            entry = line.strip().rstrip(",").strip('"')
+            if entry.startswith(name):
+                return entry
+    raise AssertionError(f"{name} is not declared in [project].dependencies")
+
+
+def test_mcp_excludes_the_2x_line():
+    """mcp 2.x renamed FastMCP; without an upper bound every fresh install breaks."""
+    dep = _dependency("mcp")
+    assert "<2" in dep, f"mcp must exclude the 2.x line, got {dep!r}"
+
+
+def test_mcp_has_a_lower_bound():
+    """An unbounded floor lets a resolver pick a version predating FastMCP."""
+    dep = _dependency("mcp")
+    assert re.search(r">=\s*\d+\.\d+", dep), f"mcp needs a lower bound, got {dep!r}"

--- a/tests/test_packaging_constraints.py
+++ b/tests/test_packaging_constraints.py
@@ -42,28 +42,55 @@ import re
 
 PYPROJECT = os.path.join(os.path.dirname(__file__), "..", "pyproject.toml")
 
+# The floor is where `instructions=` starts being honoured, measured against the
+# built wheel with --no-deps so the version under test is the one installed:
+#
+#   mcp 1.2.0   imports, serves 42 tools, instructions DROPPED SILENTLY
+#   mcp 1.3.0   imports, serves 42 tools, instructions present (3546 chars)
+#
+# Below 1.3.0 nothing raises. FastMCP.__init__(self, name=None, **settings)
+# swallows the keyword, so the server starts and quietly loses the whole agent
+# contract -- which is worse than the 2.x break, because that one at least fails
+# loudly at import.
+MIN_SUPPORTED = (1, 3, 0)
 
-def _dependency(name):
-    """The dependency entry for `name`.
 
-    Collect lines until the array's closing bracket on its own line -- splitting
-    on the first "]" truncates inside "mcp[cli]" and silently returns a partial
-    entry, which is a test that passes for the wrong reason.
+def _dependency(name, text=None):
+    """The dependency entry for `name` from [project].dependencies.
+
+    Two shapes defeated earlier versions of this helper, both found by review:
+
+      * splitting on the first "]" truncates inside "mcp[cli]";
+      * `startswith(name)` matches "mcp-extras", and an inline comment
+        mentioning "<2" satisfied the bound check while the real entry was
+        unbounded -- and this repo already writes trailing comments on
+        dependency lines (ruff==0.16.1 carries one).
+
+    So: strip comments, and match the distribution name on a boundary.
+    tomllib is not an option -- CI runs Python 3.10.
     """
-    with open(PYPROJECT) as f:
-        lines = f.read().splitlines()
+    if text is None:
+        with open(PYPROJECT) as f:
+            text = f.read()
     inside = False
-    for line in lines:
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
         if line.startswith("dependencies = ["):
             inside = True
             continue
         if inside:
             if line.strip() == "]":
                 break
-            entry = line.strip().rstrip(",").strip('"')
-            if entry.startswith(name):
+            entry = line.strip().rstrip(",").strip('"').strip("'")
+            if re.match(rf"{re.escape(name)}(\[|[<>=!~;\s]|$)", entry):
                 return entry
     raise AssertionError(f"{name} is not declared in [project].dependencies")
+
+
+def _floor(dep):
+    """The declared lower bound as a tuple, or None when there is not one."""
+    m = re.search(r">=\s*(\d+(?:\.\d+)*)", dep)
+    return tuple(int(part) for part in m.group(1).split(".")) if m else None
 
 
 def test_mcp_excludes_the_2x_line():
@@ -72,7 +99,37 @@ def test_mcp_excludes_the_2x_line():
     assert "<2" in dep, f"mcp must exclude the 2.x line, got {dep!r}"
 
 
-def test_mcp_has_a_lower_bound():
-    """An unbounded floor lets a resolver pick a version predating FastMCP."""
+def test_mcp_floor_is_at_least_the_version_that_honours_instructions():
+    """A floor must exist AND be high enough to matter.
+
+    Asserting only that some ">=" is present accepts ">=0.1", which reintroduces
+    the silent instruction loss above. Compare numerically instead, so raising
+    the floor stays fine and lowering it past the measured boundary fails.
+    """
     dep = _dependency("mcp")
-    assert re.search(r">=\s*\d+\.\d+", dep), f"mcp needs a lower bound, got {dep!r}"
+    floor = _floor(dep)
+    assert floor is not None, f"mcp needs a lower bound, got {dep!r}"
+    assert floor >= MIN_SUPPORTED, (
+        f"mcp floor {floor} is below {MIN_SUPPORTED}, where `instructions=` is "
+        f"silently dropped and the server loses its agent contract; got {dep!r}"
+    )
+
+
+def test_parser_is_not_fooled_by_a_comment_that_mentions_the_bound():
+    """A trailing comment must not satisfy the bound check."""
+    text = 'dependencies = [\n    "mcp[cli]>=1.9.0",  # never let this go <2\n]\n'
+    assert _dependency("mcp", text) == "mcp[cli]>=1.9.0"
+
+
+def test_parser_does_not_match_a_different_distribution_by_prefix():
+    """ "mcp-extras" is not "mcp"."""
+    text = 'dependencies = [\n    "mcp-extras>=1.0,<2",\n    "mcp[cli]>=1.9.0,<2",\n]\n'
+    assert _dependency("mcp", text) == "mcp[cli]>=1.9.0,<2"
+
+
+def test_parser_finds_a_bare_name_and_an_extras_form():
+    for text, expected in (
+        ('dependencies = [\n    "mcp",\n]\n', "mcp"),
+        ('dependencies = [\n    "mcp[cli]>=1.3.0,<2",\n]\n', "mcp[cli]>=1.3.0,<2"),
+    ):
+        assert _dependency("mcp", text) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mcp", extras = ["cli"] }]
+requires-dist = [{ name = "mcp", extras = ["cli"], specifier = ">=1.9.0,<2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# What does this PR do?

Bounds the one runtime dependency: `mcp[cli]` → `mcp[cli]>=1.9.0,<2`.

Found while smoke-testing the built wheel before tagging v0.6.0. `pip install isaacsim-mcp-server` resolved **mcp 2.1.1**, where `FastMCP` was renamed to `MCPServer`, so every fresh install died on import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x, where
FastMCP was renamed to MCPServer (from mcp.server.mcpserver import MCPServer) and
other APIs changed; ... or pin 'mcp<2' to keep running v1 code.
```

The wheel declared `Requires-Dist: mcp[cli]` with no bounds at all. Tagging would have published a 0.6.0 that cannot start, on a version number PyPI will not let us reuse.

**Nothing in the repository could catch this.** `uv.lock` pins mcp 1.28.1, so `uv run` works and the repo looks healthy; CI installs only `ruff` and `pytest` by pip and never installs the package or its dependencies; and the unit tests import `isaac_mcp` from the source tree rather than from a resolved environment. It is visible only by installing the built wheel into a clean venv.

Both bounds are measured against the built wheel, not guessed — each installed into a clean venv and driven over stdio the way a client would:

| mcp | Result |
|---|---|
| 1.9.0 | 42 tools, instructions intact, clean error when Isaac Sim is absent |
| 1.15.0 | imports |
| 1.28.1 | imports (what the lock pins, and what the 0.6.0 device sweep ran on) |
| 2.1.1 | `ModuleNotFoundError` on import |

Adds `tests/test_packaging_constraints.py` as a regression guard on both bounds.

Fixes # (no issue — found during pre-release verification)

## Tested Isaac Sim Version(s)

- [x] Isaac Sim 5.1.x
- [ ] Isaac Sim 4.5.x
- [ ] Isaac Sim 4.2.x
- [x] Other (please specify): **Isaac Sim 6.0.1-rc.7 (PhysX)**

Verified by installing the rebuilt wheel **unpinned** into a clean venv (pip resolves mcp 1.29.1) and driving the installed `isaacsim-mcp-server` console script against a live instance:

- **6.0.1-rc.7 PhysX** — 5/5: `get_scene_info` reached the extension, `get_simulation_state` reported `engine=physx` / `isaacsim_version=6.0.1-rc.7`, `create_object` landed, 20 steps put the cube at `-3.27 m/s`, no `velocity_warning`.
- **5.1.0** — 5/5: same flow; `get_simulation_state` correctly omits `engine`/`isaacsim_version`, which is the documented V5 contract ("absent on 5.1, which is PhysX").
- Wheel-level checks on both, 12/12: console script launches as an MCP server, 42 tools advertised, instructions survive packaging, and a tool call with no Isaac Sim running returns a clean `status: error` instead of crashing.

**Newton was not run for this change, deliberately.** This PR changes a dependency bound in `pyproject.toml` and touches no extension code, and the extension is the only thing that differs between PhysX and Newton. 5.1 + 6.0.1 PhysX already exercises both adapters through the installed wheel; a Newton boot would re-verify the same packaging path and add no signal about the bound. Flagging it explicitly rather than implying coverage that was not taken.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guidelines](https://github.com/whats2000/isaacsim-mcp-server/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue? — no; found during pre-release wheel verification.
- [ ] Did you make sure to update the documentation with your changes? — no user-facing docs affected; install instructions are unchanged.
- [x] Did you run the linter (`ruff check . && ruff format .`)?
- [x] Did you write any new necessary tests? — `tests/test_packaging_constraints.py`; suite is 268 passed / 43 skipped.
- [x] Did you **manually test** the behavior in a running Isaac Sim instance? (unit tests alone are not sufficient)

## Who can review?

@whats2000 — release blocker for v0.6.0; this should land before the tag.

---

**Follow-up, not in this PR:** CI still never installs the built artifact, so this class of defect remains invisible to it. A job that runs `hatch build`, installs the wheel into a clean venv and starts the server would close it permanently. Left out to keep this PR to the blocker alone.
