### PR TITLE
docs: PR template lists the versions this project actually supports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,11 +19,18 @@ Fixes # (issue)
 List every Isaac Sim version you have tested this PR against.
 Running unit tests alone is NOT sufficient — you must verify the behavior
 inside a running Isaac Sim instance.
+
+6.0 ships two physics backends and they are separate runtimes, not a detail:
+a fault that appears on one and not the other is itself the finding. Tick the
+one(s) you actually ran, and say which you did not — stating a gap is fine,
+implying coverage you do not have is not.
+
+Only one Isaac Sim instance can run per GPU, so these are sequential runs.
 -->
 
+- [ ] Isaac Sim 6.0.x — PhysX (`isaac-sim.sh`)
+- [ ] Isaac Sim 6.0.x — Newton (`isaac-sim.newton.sh`)
 - [ ] Isaac Sim 5.1.x
-- [ ] Isaac Sim 4.5.x
-- [ ] Isaac Sim 4.2.x
 - [ ] Other (please specify):
 
 ## Before submitting


### PR DESCRIPTION
# What does this PR do?

Updates the "Tested Isaac Sim Version(s)" checkboxes in `.github/PULL_REQUEST_TEMPLATE.md`.

The list still read 5.1.x / 4.5.x / 4.2.x, inherited from upstream. This project supports **Isaac Sim 5.1.0 – 6.0.1** (README badge, `pyproject.toml` description), and 4.5/4.2 appear nowhere in the README or CONTRIBUTING — so the template asked contributors to tick runtimes that are not supported, while offering no box for the one 0.6.0 is built on.

```
- [ ] Isaac Sim 6.0.x — PhysX (`isaac-sim.sh`)
- [ ] Isaac Sim 6.0.x — Newton (`isaac-sim.newton.sh`)
- [ ] Isaac Sim 5.1.x
- [ ] Other (please specify):
```

**Why 6.0 gets two boxes rather than one.** The backends are separate runtimes, not a configuration detail. This cycle produced faults that reproduce on Newton and not PhysX (joint drives not converging; an orphan joint aborting Newton's model build for the whole session) and others that were the reverse. A single 6.0 tick would hide precisely the distinction that matters, and the changelog policy in `CLAUDE.md` already treats a version-specific fault as a finding in its own right.

The comment block also asks contributors to name the runtime they *did not* run. Every honest PR has gaps; the failure mode is implying coverage that was not taken.

Fixes # (no issue — noticed while filling the template out for #33)

## Tested Isaac Sim Version(s)

- [ ] Isaac Sim 6.0.x — PhysX (`isaac-sim.sh`)
- [ ] Isaac Sim 6.0.x — Newton (`isaac-sim.newton.sh`)
- [ ] Isaac Sim 5.1.x
- [ ] Other (please specify):

Not applicable: this changes a Markdown template only. No code, no tooling, nothing that reaches a running Isaac Sim.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guidelines](https://github.com/whats2000/isaacsim-mcp-server/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue? — no.
- [x] Did you make sure to update the documentation with your changes? — this PR is the documentation change.
- [x] Did you run the linter (`ruff check . && ruff format .`)?
- [ ] Did you write any new necessary tests? — not applicable to a Markdown template.
- [ ] Did you **manually test** the behavior in a running Isaac Sim instance? — not applicable; see above.

## Who can review?

@whats2000 — independent of #33 and can merge in either order.
