### PR TITLE
ci: publish to the MCP Registry on every tagged release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,59 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  publish-registry:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # mcp-publisher login github-oidc; no stored secret
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stamp the tag version into server.json
+        # server.json carries the version twice and the registry rejects a
+        # publish whose package version is not on PyPI. Deriving both from the
+        # tag is what keeps the listing from drifting: 0.5.0 through 0.6.0 all
+        # shipped to PyPI while the registry entry sat at 0.4.1, because this
+        # step did not exist and nobody bumped it by hand.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: Wait for the release to be visible on PyPI
+        # The registry validates ownership by fetching the PyPI metadata for
+        # this exact version and looking for the `mcp-name:` marker that
+        # README.md puts in the long description. Publishing before the index
+        # has the new version fails that check, so poll rather than race it.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for _ in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/isaacsim-mcp-server/$VERSION/json" > /dev/null; then
+              echo "isaacsim-mcp-server $VERSION is on PyPI"
+              exit 0
+            fi
+            echo "waiting for isaacsim-mcp-server $VERSION on PyPI..."
+            sleep 10
+          done
+          echo "::error::isaacsim-mcp-server $VERSION never appeared on PyPI"
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to the MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the MCP Registry
+        run: ./mcp-publisher publish
+
   github-release:
     needs: build-and-publish
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ mcp_cache/
 .claude
 .superpowers
 .mcp.json
+
+# mcp-publisher binary, downloaded ad hoc for a manual registry publish
+# (the release workflow fetches its own copy into the runner workspace)
+mcp-publisher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the isaacsim-mcp-server project will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Releases publish to the MCP Registry** — a tagged release now stamps the tag version into `server.json` and runs `mcp-publisher` (GitHub Actions OIDC, no stored secret) after the PyPI upload. The listing had been hand-published and sat at 0.4.1 while 0.5.0 through 0.6.0 shipped to PyPI.
+
 ## [0.6.0] - 2026-08-31
 
 ### Added


### PR DESCRIPTION
# What does this PR do?

Adds a `publish-registry` job to the release workflow so a tagged release updates the [MCP Registry](https://registry.modelcontextprotocol.io) listing, instead of leaving it to be hand-published.

The listing was published by hand once, at 0.4.1 in April, and nothing kept it current — 0.5.0, 0.5.1, 0.5.2 and 0.6.0 all shipped to PyPI while the registry went on advertising 39 tools. Everything the registry actually requires was already here: `server.json`, and the `mcp-name:` marker in `README.md` that proves PyPI ownership. The only missing piece was the publish.

The job runs after the PyPI upload and:

1. **Stamps the tag version into both `version` fields of `server.json`.** This is the part that stops the drift — leaving them to be bumped by hand is what caused it.
2. **Waits for that version to appear on PyPI.** Ownership is verified by fetching the exact version's metadata and looking for the marker, so a publish that races the index fails the check.
3. **Installs `mcp-publisher`, validates, `login github-oidc`, publishes.** OIDC means no stored secret — just `id-token: write` on the job.

0.6.0 was backfilled to the registry by hand, so the listing is current today; the automation takes over at the next tag.

Also gitignores the `mcp-publisher` binary, which lands in the repo root if you run the manual publish from there.

## Tested Isaac Sim Version(s)

- [ ] Isaac Sim 6.0.x — PhysX (`isaac-sim.sh`)
- [ ] Isaac Sim 6.0.x — Newton (`isaac-sim.newton.sh`)
- [ ] Isaac Sim 5.1.x
- [x] Other (please specify): **none — and deliberately so.** This PR touches no runtime code: no adapter, handler, tool or extension module is modified, so there is no behavior a running simulator could exercise. Stating the gap rather than implying coverage: this was not run against any Isaac Sim instance.

What *was* verified, against the real tooling rather than by reading the YAML:

- The `jq` stamp step run verbatim with `GITHUB_REF_NAME=v0.6.1` → both `version` fields rewritten to `0.6.1`.
- The `curl | tar` install line run verbatim → working `mcp-publisher`, whose `login --help` lists `github-oidc` as a supported method.
- `mcp-publisher validate` on both the repo's `server.json` and the stamped copy → `✅ server.json is valid`.
- The PyPI poll against 0.6.0 (found, exits immediately) and against a nonexistent 9.9.9 (retries, then fails loudly).
- `ruff check . && ruff format --check .` clean; `pytest` 271 passed / 43 skipped; workflow parses with the job graph intact (`publish-registry` needs `build-and-publish`).

Not verifiable without pushing a tag: the end-to-end publish, and the OIDC-to-namespace grant (`io.github.whats2000/*` from `whats2000/isaacsim-mcp-server`) — the docs state it as a pattern. The first tagged release is the real test, and it fails visibly rather than silently if the grant is wrong.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case). — release infrastructure only, no runtime code.
- [x] Did you read the [contributor guidelines](https://github.com/whats2000/isaacsim-mcp-server/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? — `CHANGELOG.md` under a new `[Unreleased]` heading.
- [x] Did you run the linter (`ruff check . && ruff format .`)?
- [ ] Did you write any new necessary tests? — no unit test can cover a workflow that only runs on a tag push; the steps were exercised directly instead, as listed above.
- [ ] Did you **manually test** the behavior in a running Isaac Sim instance? (unit tests alone are not sufficient) — n/a, see above.

## Who can review?

@whats2000

🤖 Generated with [Claude Code](https://claude.com/claude-code)
