### PR TITLE
docs: add the Glama server score badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Quality](https://archestra.ai/mcp-catalog/api/badge/quality/whats2000/isaacsim-mcp-server)](https://archestra.ai/mcp-catalog/api/badge/quality/whats2000/isaacsim-mcp-server)
+[![isaacsim-mcp-server MCP server](https://glama.ai/mcp/servers/whats2000/isaacsim-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/whats2000/isaacsim-mcp-server)
 
 > Natural language control for NVIDIA Isaac Sim through the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP).
 


### PR DESCRIPTION
# What does this PR do?

Adds the Glama score badge to the README badge row, next to the existing Archestra quality badge.

The listing at [glama.ai/mcp/servers/whats2000/isaacsim-mcp-server](https://glama.ai/mcp/servers/whats2000/isaacsim-mcp-server) is already claimed under the personal account and publishes a live maintenance/quality score (license A, quality A, maintenance A), so the badge tracks that rather than being a static shield.

No `glama.json` accompanies this. Glama only *requires* that file to claim an **org-hosted** repo — a personal repo is claimed by GitHub auth alone — and its [schema](https://glama.ai/mcp/schemas/server.json) defines exactly one property, `maintainers`. It would be inert here. If the repo ever moves to an org, or a second maintainer needs Glama dashboard access, that is the moment to add it.

One line changed in `README.md`. No `CHANGELOG.md` entry: a README badge is not user-facing behavior in the sense that file tracks.

## Tested Isaac Sim Version(s)

Not applicable — docs-only, no code path touched, so nothing was run in a live simulator.

- [ ] Isaac Sim 6.0.x — PhysX (`isaac-sim.sh`)
- [ ] Isaac Sim 6.0.x — Newton (`isaac-sim.newton.sh`)
- [ ] Isaac Sim 5.1.x
- [x] Other (please specify): none — README badge row only

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guidelines](https://github.com/whats2000/isaacsim-mcp-server/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? (the README *is* the change)
- [ ] Did you run the linter (`ruff check . && ruff format .`)? — no `.py` files touched
- [ ] Did you write any new necessary tests? — none apply
- [ ] Did you **manually test** the behavior in a running Isaac Sim instance? — docs-only

## Who can review?

@whats2000

🤖 Generated with [Claude Code](https://claude.com/claude-code)