### PR TITLE
fix: use the existing enhancement label in the feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: "\U0001F680 Feature Request"
 description: Submit a proposal or request for a new feature
-labels: ["Feature request"]
+labels: ["enhancement"]
 body:
   - type: textarea
     id: feature-request


### PR DESCRIPTION
## Summary

`.github/ISSUE_TEMPLATE/feature-request.yml` assigned `labels: ["Feature request"]`, a label that does not exist on this repository, so issues opened through the Feature Request form land unlabelled.

```diff
-labels: ["Feature request"]
+labels: ["enhancement"]
```

## Why `enhancement` rather than a new label

The repo already has `enhancement`, and it is what #40 ended up carrying after the CLI refused the templated label. Creating a second label meaning "feature request" would need a convention to keep the two untangled; reusing the existing one keeps it at one label per concept.

## Verification

- `gh api repos/whats2000/isaacsim-mcp-server/labels --jq '.[].name'` lists `enhancement` and does **not** list `Feature request`.
- `bug-report.yml` was already correct (`labels: ["bug"]`); `config.yml` assigns no labels. This was the only template affected.

Repository configuration only — no package code changes, so no CHANGELOG entry (a user of 0.6.1 cannot hit this) and no live Isaac Sim sweep applies.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)